### PR TITLE
undefine previously generated methods before creating new ones

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -29,15 +29,12 @@ module Dynamoid #:nodoc:
       def field(name, type = :string, options = {})
         named = name.to_s
         self.attributes[name] = {:type => type}.merge(options)
-        define_method(named) do
-          read_attribute(named)
-        end
-        define_method("#{named}=") do |value|
-          write_attribute(named, value)
-        end
-        define_method("#{named}?") do
-          !read_attribute(named).nil?
-        end
+
+        define_method(named) { read_attribute(named) }
+        define_method("#{named}?") { !read_attribute(named).nil? }
+        define_method("#{named}=") {|value| write_attribute(named, value) }
+
+        undefine_attribute_methods
         define_attribute_methods(self.attributes.keys)
       end
     end
@@ -53,7 +50,7 @@ module Dynamoid #:nodoc:
     #
     # @since 0.2.0
     def write_attribute(name, value)
-      self.send("#{name}_will_change!".to_sym) unless self.read_attribute(name) == value
+      attribute_will_change!(name) unless self.read_attribute(name) == value
       attributes[name.to_sym] = value
     end
     alias :[]= :write_attribute

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -8,6 +8,14 @@ describe "Dynamoid::Document" do
     @address.new_record.should be_true
     @address.attributes.should == {:id=>nil, :created_at=>nil, :updated_at=>nil, :city=>nil, :options=>nil}
   end
+
+  it 'responds to will_change! methods for all fields' do
+    @address = Address.new
+    @address.should respond_to(:id_will_change!)
+    @address.should respond_to(:options_will_change!)
+    @address.should respond_to(:created_at_will_change!)
+    @address.should respond_to(:updated_at_will_change!)
+  end
   
   it 'initializes a new document with attributes' do
     @address = Address.new(:city => 'Chicago')


### PR DESCRIPTION
couldn't find a way to write a failing test for it but in my app the only dirty attribute methods that were getting generated were from id (not created_at, updated_at, etc).

Here's some IRB output from prior to the change:

```
1.9.3p125 :002 > class Foo; include Dynamoid::Document; field :created_at; end
nil
1.9.3p125 :003 > f = Foo.new
#<Foo:0x007f98f930c7f0 @new_record=true, @attributes={:id=>nil, :created_at=>nil, :updated_at=>nil}>
1.9.3p125 :004 > f.methods.grep /change/
[
    [0]            changed()      Foo (ActiveModel::Dirty)
    [1]           changed?()      Foo (ActiveModel::Dirty)
    [2] changed_attributes()      Foo (ActiveModel::Dirty)
    [3]            changes()      Foo (ActiveModel::Dirty)
    [4]          id_change(*args) Foo (
    [5]        id_changed?(*args) Foo (
    [6]    id_will_change!(*args) Foo (
    [7]   previous_changes()      Foo (ActiveModel::Dirty)
]
```

and then after it:

```
1.9.3p125 :001 > class Foo; include Dynamoid::Document; field :created_at; end
true
1.9.3p125 :002 > f = Foo.new
#<Foo:0x007ff9b0e7aae8 @new_record=true, @attributes={:id=>nil, :created_at=>nil, :updated_at=>nil}>
1.9.3p125 :003 > f.methods.grep /change/
[
    [ 0]                 changed()      Foo (ActiveModel::Dirty)
    [ 1]                changed?()      Foo (ActiveModel::Dirty)
    [ 2]      changed_attributes()      Foo (ActiveModel::Dirty)
    [ 3]                 changes()      Foo (ActiveModel::Dirty)
    [ 4]       created_at_change(*args) Foo (
    [ 5]     created_at_changed?(*args) Foo (
    [ 6] created_at_will_change!(*args) Foo (
    [ 7]               id_change(*args) Foo (
    [ 8]             id_changed?(*args) Foo (
    [ 9]         id_will_change!(*args) Foo (
    [10]        previous_changes()      Foo (ActiveModel::Dirty)
    [11]       updated_at_change(*args) Foo (
    [12]     updated_at_changed?(*args) Foo (
    [13] updated_at_will_change!(*args) Foo (
]
```
