### PR TITLE
cleanup

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -34,8 +34,7 @@ module Dynamoid #:nodoc:
         define_method("#{named}?") { !read_attribute(named).nil? }
         define_method("#{named}=") {|value| write_attribute(named, value) }
 
-        undefine_attribute_methods
-        define_attribute_methods(self.attributes.keys)
+        define_attribute_method(name)
       end
     end
     


### PR DESCRIPTION
uses `define_attribute_method` instead of 
`undefine_attribute_methods  and define_attribute_methods`
