### PR TITLE
cache table so that we don't make describe_table request every time

### DIFF
--- a/lib/dynamoid/adapter/aws_sdk.rb
+++ b/lib/dynamoid/adapter/aws_sdk.rb
@@ -80,8 +80,7 @@ module Dynamoid
       #
       # @since 0.2.0
       def delete_item(table_name, key, range_key = nil)
-        table = @@connection.tables[table_name]
-        table.load_schema
+        table = get_table(table_name)
         result = if table.composite_key?
           table.items.at(key, range_key)
         else
@@ -113,8 +112,7 @@ module Dynamoid
       #
       # @since 0.2.0
       def get_item(table_name, key, range_key = nil)
-        table = @@connection.tables[table_name]
-        table.load_schema
+        table = get_table(table_name)
         result = if table.composite_key?
           table.items.at(key, range_key)
         else
@@ -141,8 +139,7 @@ module Dynamoid
       #
       # @since 0.2.0
       def put_item(table_name, object)
-        table = @@connection.tables[table_name]
-        table.load_schema
+        table = get_table(table_name)
         table.items.create(object.delete_if{|k, v| v.nil? || (v.respond_to?(:empty?) && v.empty?)})
       end
     
@@ -163,8 +160,7 @@ module Dynamoid
       #
       # @since 0.2.0
       def query(table_name, opts = {})
-        table = @@connection.tables[table_name]
-        table.load_schema
+        table = get_table(table_name)
         
         if table.composite_key?
           results = []
@@ -185,8 +181,7 @@ module Dynamoid
       #
       # @since 0.2.0
       def scan(table_name, scan_hash)
-        table = @@connection.tables[table_name]
-        table.load_schema
+        table = get_table(table_name)
         results = []
         table.items.where(scan_hash).select do |data|
           results << data.attributes.symbolize_keys!
@@ -197,6 +192,19 @@ module Dynamoid
       # @todo Add an UpdateItem method.
     
       # @todo Add an UpdateTable method.
+
+      def get_table(table_name)
+        unless table = table_cache[table_name]
+          table = @@connection.tables[table_name]
+          table.load_schema
+          table_cache[table_name] = table
+        end
+        table
+      end
+
+      def table_cache
+        @table_cache ||= {}
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,8 +34,7 @@ RSpec.configure do |config|
     config.before(:each) do
       Dynamoid::Adapter.list_tables.each do |table|
         if table =~ /^#{Dynamoid::Config.namespace}/
-          table = Dynamoid::Adapter.connection.tables[table]
-          table.load_schema
+          table = Dynamoid::Adapter.get_table(table)
           table.items.each {|i| i.delete}
         end
       end      


### PR DESCRIPTION
`@@connection.tables[table_name]` [ln](https://github.com/amazonwebservices/aws-sdk-for-ruby/blob/master/lib/aws/dynamo_db/table_collection.rb#L110) creates a new table which in turn issues a describeTable request to the db. we can avoid the additional describeTable request by caching the table.
