### PR TITLE
don't load association target unnecessarily

### DIFF
--- a/lib/dynamoid/associations.rb
+++ b/lib/dynamoid/associations.rb
@@ -91,17 +91,16 @@ module Dynamoid
         field "#{name}_ids".to_sym, :set
         self.associations[name] = options.merge(:type => type)
         define_method(name) do
-          @associations ||= {}
-          @associations[name] ||= Dynamoid::Associations.const_get(type.to_s.camelcase).new(self, name, options)
+          @associations[:"#{name}_ids"] ||= Dynamoid::Associations.const_get(type.to_s.camelcase).new(self, name, options)
         end
         define_method("#{name}=".to_sym) do |objects|
-          @associations ||= {}
-          @associations[name] ||= Dynamoid::Associations.const_get(type.to_s.camelcase).new(self, name, options)
-          @associations[name].setter(objects)
+          @associations[:"#{name}_ids"] ||= Dynamoid::Associations.const_get(type.to_s.camelcase).new(self, name, options)
+          @associations[:"#{name}_ids"].setter(objects)
         end
       end
     end
-    
+
+
   end
   
 end

--- a/lib/dynamoid/associations/association.rb
+++ b/lib/dynamoid/associations/association.rb
@@ -6,7 +6,7 @@ module Dynamoid #:nodoc:
   # The target is the object which is referencing by this association.
   module Associations
     module Association
-      attr_accessor :name, :options, :source
+      attr_accessor :name, :options, :source, :loaded
 
       # Create a new association.
       #
@@ -24,7 +24,30 @@ module Dynamoid #:nodoc:
         @name = name
         @options = options
         @source = source
+        @loaded = false
       end
+
+      def loaded?
+        @loaded
+      end
+
+      def find_target
+      end
+
+      def target
+        unless loaded?
+          @target = find_target
+          @loaded = true
+        end
+
+        @target
+      end
+
+      def reset
+        @target = nil
+        @loaded = false
+      end
+
 
       private
 

--- a/lib/dynamoid/associations/belongs_to.rb
+++ b/lib/dynamoid/associations/belongs_to.rb
@@ -5,7 +5,6 @@ module Dynamoid #:nodoc:
   # object to which the association object is associated.
   module Associations
     class BelongsTo
-      include Association
       include SingleAssociation
 
       private

--- a/lib/dynamoid/associations/has_and_belongs_to_many.rb
+++ b/lib/dynamoid/associations/has_and_belongs_to_many.rb
@@ -4,7 +4,6 @@ module Dynamoid #:nodoc:
   # The has and belongs to many association.
   module Associations
     class HasAndBelongsToMany
-      include Association
       include ManyAssociation
 
       private

--- a/lib/dynamoid/associations/has_many.rb
+++ b/lib/dynamoid/associations/has_many.rb
@@ -4,7 +4,6 @@ module Dynamoid #:nodoc:
   # The has_many association.
   module Associations
     class HasMany
-      include Association
       include ManyAssociation
 
       private

--- a/lib/dynamoid/associations/many_association.rb
+++ b/lib/dynamoid/associations/many_association.rb
@@ -3,6 +3,7 @@ module Dynamoid #:nodoc:
 
   module Associations
     module ManyAssociation
+      include Association
 
       attr_accessor :query
 
@@ -20,13 +21,15 @@ module Dynamoid #:nodoc:
       # @return the association records; depending on which association this is, either a single instance or an array
       #
       # @since 0.2.0
-      def records
-        results = Array(target_class.find(source_ids.to_a))
+      def find_target
+        Array(target_class.find(source_ids.to_a))
+      end
 
+      def records
         if query.empty?
-          results
+          target
         else
-          results_with_query(results)
+          results_with_query(target)
         end
       end
 
@@ -78,7 +81,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def setter(object)
-        records.each {|o| delete(o)}
+        target.each {|o| delete(o)}
         self << (object)
         object
       end
@@ -120,7 +123,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def destroy_all
-        objs = records
+        objs = target
         source.update_attribute(source_attribute, nil)
         objs.each(&:destroy)
       end
@@ -129,7 +132,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def delete_all
-        objs = records
+        objs = target
         source.update_attribute(source_attribute, nil)
         objs.each(&:delete)
       end

--- a/lib/dynamoid/associations/single_association.rb
+++ b/lib/dynamoid/associations/single_association.rb
@@ -3,6 +3,7 @@ module Dynamoid #:nodoc:
 
   module Associations
     module SingleAssociation
+      include Association
 
       delegate :class, :to => :target
 
@@ -59,7 +60,7 @@ module Dynamoid #:nodoc:
       # @return [Dynamoid::Document] the found target (or nil if nothing)
       #
       # @since 0.2.0
-      def target
+      def find_target
         return if source_ids.empty?
         target_class.find(source_ids.first)
       end

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -68,6 +68,7 @@ module Dynamoid #:nodoc:
     def initialize(attrs = {})
       @new_record = true
       @attributes ||= {}
+      @associations ||= {}
 
       self.class.undump(attrs).each {|key, value| send "#{key}=", value }
     end
@@ -88,6 +89,7 @@ module Dynamoid #:nodoc:
     # @since 0.2.0        
     def reload
       self.attributes = self.class.find(self.id).attributes
+      @associations.values.each(&:reset)
       self
     end
   end

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -61,6 +61,11 @@ module Dynamoid #:nodoc:
       end
 
       attribute_will_change!(name) unless self.read_attribute(name) == value
+
+      if association = @associations[name]
+        association.reset
+      end
+
       attributes[name.to_sym] = value
     end
     alias :[]= :write_attribute

--- a/spec/dynamoid/associations/association_spec.rb
+++ b/spec/dynamoid/associations/association_spec.rb
@@ -37,12 +37,16 @@ describe "Dynamoid::Associations::Association" do
 
   it 'returns the number of items in the association' do
     @magazine.subscriptions.create
-    
     @magazine.subscriptions.size.should == 1
     
-    @magazine.subscriptions.create
-    
+    @second = @magazine.subscriptions.create
     @magazine.subscriptions.size.should == 2
+
+    @magazine.subscriptions.delete(@second)
+    @magazine.subscriptions.size.should == 1
+
+    @magazine.subscriptions = []
+    @magazine.subscriptions.size.should == 0
   end
   
   it 'assigns directly via the equals operator' do
@@ -108,7 +112,7 @@ describe "Dynamoid::Associations::Association" do
 
   it 'destroys associations' do
     @subscription = Subscription.new
-    @magazine.subscriptions.expects(:records).returns([@subscription])
+    @magazine.subscriptions.expects(:target).returns([@subscription])
     @subscription.expects(:destroy)
 
     @magazine.subscriptions.destroy_all
@@ -116,7 +120,7 @@ describe "Dynamoid::Associations::Association" do
 
   it 'deletes associations' do
     @subscription = Subscription.new
-    @magazine.subscriptions.expects(:records).returns([@subscription])
+    @magazine.subscriptions.expects(:target).returns([@subscription])
     @subscription.expects(:delete)
 
     @magazine.subscriptions.delete_all
@@ -176,6 +180,14 @@ describe "Dynamoid::Associations::Association" do
     @magazine.subscriptions.class.should == Array
     @magazine.subscriptions.create
     @magazine.subscriptions.class.should == Array
+  end
+
+  it 'loads association one time only' do
+    @sponsor = @magazine.sponsor.create
+    @magazine.sponsor.expects(:find_target).once.returns(@sponsor)
+
+    @magazine.sponsor.id
+    @magazine.sponsor.id
   end
 
 end


### PR DESCRIPTION
This patch adds checks so that association does't load the target multiple times.
