### PR TITLE
Fixes bug where setting a range key on a table fails due to :number vs :integer/:float

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -31,12 +31,18 @@ module Dynamoid
       #
       # @since 0.4.0
       def create_table(options = {})
+        if self.range_key
+          range_key_type = [:integer, :float].include?(attributes[range_key][:type]) ? :number : attributes[range_key][:type]
+          range_key_hash = { range_key => range_key_type}
+        else
+          range_key_hash = nil
+        end
         options = {
           :id => self.hash_key,
           :table_name => self.table_name,
           :write_capacity => self.write_capacity,
           :read_capacity => self.read_capacity,
-          :range_key => self.range_key ? {range_key => attributes[range_key][:type]} : nil
+          :range_key => range_key_hash
         }.merge(options)
 
         return true if table_exists?(options[:table_name])


### PR DESCRIPTION
DynamoDB expects the type of a range key to be either :string or :number, but Dynamoid allows for :string, :float, or :integer on any field type (and calling the range method calls the field method).

``` ruby
range :level, :integer
```

fails on table creation, because Dynamo wants :number, but

``` ruby
range :level, :number
```

allows for table creation but fails on putting items into the table because :number is not supported by Dynamoid. This patch allows you to do what you'd expect:

``` ruby
range :level, :integer
```

and on table creation converts :integer and :float to :number.
