### PR TITLE
Fixed bug where trying to delete an item with a range key failed.

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -146,7 +146,7 @@ module Dynamoid
     # @since 0.2.0
     def delete
       delete_indexes
-      options = range_key ? {:range_key => attributes[range_key]} : nil
+      options = range_key ? {:range_key => attributes[range_key]} : {}
       Dynamoid::Adapter.delete(self.class.table_name, self.hash_key, options)
     end
 


### PR DESCRIPTION
Delete method wasn't checking if a range key was set, and Dynamo would barf due to not specifying a range key. Fixed.

Also, using a custom hash_key field was failing due to delete assuming hash_key was named :id. Now it looks it up
