### PR TITLE
Added default value support

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -75,7 +75,11 @@ module Dynamoid
       #
       # @since 0.2.0
       def undump_field(value, options)
-        return if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+        if options[:default] && value.nil?
+          value = options[:default]
+        else
+          return if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+        end
 
         case options[:type]
         when :string


### PR DESCRIPTION
You can now give a default value to fields:

``` ruby
class User
  include Dynamoid::Document
  field :username,  :string, default: 'Frankenstein'
end
```
