### PR TITLE
use hash_key instead of using 'id'. see #43

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -201,7 +201,7 @@ module Dynamoid #:nodoc:
 
       def range?
         return false unless source.range_key
-        query_keys == ['id'] || (query_keys.to_set == ['id', source.range_key.to_s].to_set)
+        query_keys == [source.hash_key.to_s] || (query_keys.to_set == [source.hash_key.to_s, source.range_key.to_s].to_set)
       end
 
       def start_key

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -88,10 +88,10 @@ describe "Dynamoid::Associations::Chain" do
 
   it 'finds range querys' do
     @chain = Dynamoid::Criteria::Chain.new(Tweet)
-    @chain.query = { :id => 'test' }
+    @chain.query = { :tweet_id => 'test' }
     @chain.send(:range?).should be_true
 
-    @chain.query = {:id => 'test', :group => 'xx'}
+    @chain.query = {:tweet_id => 'test', :group => 'xx'}
     @chain.send(:range?).should be_true
 
     @chain.query = { :group => 'xx' }
@@ -100,32 +100,32 @@ describe "Dynamoid::Associations::Chain" do
     @chain.query = { :group => 'xx', :msg => 'hai' }
     @chain.send(:range?).should be_false
   end
-  
+
   context 'range queries' do
     before do
       @tweet1 = Tweet.create(:tweet_id => "x", :group => "one")
       @tweet2 = Tweet.create(:tweet_id => "x", :group => "two")
-      @tweet3 = Tweet.create(:tweet_id => "xx", :group => "two")      
+      @tweet3 = Tweet.create(:tweet_id => "xx", :group => "two")
       @chain = Dynamoid::Criteria::Chain.new(Tweet)
     end
-    
+
     it 'finds tweets with a simple range query' do
       @chain.query = { :tweet_id => "x" }
       @chain.send(:records_with_range).size.should == 2
       @chain.all.size.should == 2
-      @chain.limit(1).size.should == 1      
+      @chain.limit(1).size.should == 1
     end
-    
+
     it 'finds tweets with a start' do
       @chain.query = { :tweet_id => "x" }
       @chain.start(@tweet1)
       @chain.all.should =~ [@tweet2]
     end
-    
+
     it 'finds one specific tweet' do
       @chain = Dynamoid::Criteria::Chain.new(Tweet)
       @chain.query = { :tweet_id => "xx", :group => "two" }
-      @chain.send(:records_with_range).should == [@tweet3]      
+      @chain.send(:records_with_range).should == [@tweet3]
     end
   end
 

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -57,10 +57,10 @@ describe "Dynamoid::Criteria" do
     User.where(:name => 'x').consistent.first
 
     Dynamoid::Adapter.expects(:query).with { |table_name, options| options[:consistent_read] == true }.returns([])
-    Tweet.where(:id => 'xx', :group => 'two').consistent.all
+    Tweet.where(:tweet_id => 'xx', :group => 'two').consistent.all
 
     Dynamoid::Adapter.expects(:query).with { |table_name, options| options[:consistent_read] == false }.returns([])
-    Tweet.where(:id => 'xx', :group => 'two').all
+    Tweet.where(:tweet_id => 'xx', :group => 'two').all
   end
     
 end


### PR DESCRIPTION
Now criteria handles the range query properly when custom primary key is used in the table.
