### PR TITLE
Treat deleting tables like creating tables

### DIFF
--- a/lib/dynamoid/adapter/aws_sdk.rb
+++ b/lib/dynamoid/adapter/aws_sdk.rb
@@ -98,7 +98,10 @@ module Dynamoid
       #
       # @since 0.2.0
       def delete_table(table_name)
-        @@connection.tables[table_name].delete
+        Dynamoid.logger.info "Deleting #{table_name} table. This could take a while."
+        table = @@connection.tables[table_name]
+        table.delete
+        sleep 0.5 while table.exists? == true
       end
 
       # @todo Add a DescribeTable method.


### PR DESCRIPTION
Wait until the table is deleted before continuing, warn about it potentially taking a while.
