### PR TITLE
use_ssl option added in preparation for fake_dynamo (or equivalent)

### DIFF
--- a/lib/dynamoid/adapter/aws_sdk.rb
+++ b/lib/dynamoid/adapter/aws_sdk.rb
@@ -18,7 +18,7 @@ module Dynamoid
       #
       # @since 0.2.0
       def connect!
-        @@connection = AWS::DynamoDB.new(:access_key_id => Dynamoid::Config.access_key, :secret_access_key => Dynamoid::Config.secret_key, :dynamo_db_endpoint => Dynamoid::Config.endpoint)
+        @@connection = AWS::DynamoDB.new(:access_key_id => Dynamoid::Config.access_key, :secret_access_key => Dynamoid::Config.secret_key, :dynamo_db_endpoint => Dynamoid::Config.endpoint, :use_ssl => Dynamoid::Config.use_ssl)
       end
 
       # Return the established connection.

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -3,7 +3,7 @@ require "uri"
 require "dynamoid/config/options"
 
 module Dynamoid
-  
+
   # Contains all the basic configuration information required for Dynamoid: both sensible defaults and required fields.
   module Config
     extend self
@@ -22,8 +22,9 @@ module Dynamoid
     option :partitioning, :default => false
     option :partition_size, :default => 200
     option :endpoint, :default => 'dynamodb.us-east-1.amazonaws.com'
+    option :use_ssl, :default => true
     option :included_models, :default => []
-    
+
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #
     # @since 0.2.0
@@ -37,7 +38,7 @@ module Dynamoid
     def logger
       @logger ||= default_logger
     end
-    
+
     # If you want to, set the logger manually to any output you'd like. Or pass false or nil to disable logging entirely.
     #
     # @since 0.2.0


### PR DESCRIPTION
fake_dynamo needs use_ssl set to false in the aws_sdk.

This exposes that option to Dynamoid:

``` ruby
Dynamoid.configure do |config|
  config.adapter = 'aws_sdk'
  config.access_key = 'access'
  config.secret_key = 'secret'
  config.endpoint = 'localhost'
  config.use_ssl = false
end
```
