### PR TITLE
Allow indexes for namespaced models

### DIFF
--- a/lib/dynamoid/indexes/index.rb
+++ b/lib/dynamoid/indexes/index.rb
@@ -48,7 +48,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def table_name
-        "#{Dynamoid::Config.namespace}_index_#{source.table_name.to_s.downcase}_#{name.collect(&:to_s).collect(&:pluralize).join('_and_')}"
+        "#{Dynamoid::Config.namespace}_index_" + source.table_name.sub("#{Dynamoid::Config.namespace}_", '').singularize + "_#{name.collect(&:to_s).collect(&:pluralize).join('_and_')}"
       end
 
       # Given either an object or a list of attributes, generate a hash key and a range key for the index. Optionally pass in 


### PR DESCRIPTION
Change table name of index to use table_name of the source table.
This allows creating indexes of namespaced models if they specify a name for their table. This time, without breaking the specs
