### PR TITLE
Can't delete object with DateTime range key

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -157,7 +157,7 @@ module Dynamoid
     end
 
     def update!(conditions = {}, &block)
-      options = range_key ? {:range_key => attributes[range_key]} : {}
+      options = range_key ? {:range_key => dump_field(self.read_attribute(range_key), self.class.attributes[range_key])} : {}
       new_attrs = Dynamoid::Adapter.update_item(self.class.table_name, self.hash_key, options.merge(:conditions => conditions), &block)
       load(new_attrs)
     end
@@ -184,7 +184,7 @@ module Dynamoid
     # @since 0.2.0
     def delete
       delete_indexes
-      options = range_key ? {:range_key => attributes[range_key]} : {}
+      options = range_key ? {:range_key => dump_field(self.read_attribute(range_key), self.class.attributes[range_key])} : {}
       Dynamoid::Adapter.delete(self.class.table_name, self.hash_key, options)
     end
 

--- a/spec/app/models/message.rb
+++ b/spec/app/models/message.rb
@@ -1,0 +1,9 @@
+class Message
+  include Dynamoid::Document
+
+  table name: :messages, key: :message_id, read_capacity: 200, write_capacity: 200
+
+  range :time, :datetime
+
+  field :text
+end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -162,6 +162,15 @@ describe "Dynamoid::Persistence" do
         end
       }.to raise_error(Dynamoid::Errors::ConditionalCheckFailedException)
     end
+
   end
 
+  context 'delete' do
+    it 'deletes model with datetime range key' do
+      lambda {
+        msg = Message.create!(:message_id => 1, :time => DateTime.now, :text => "Hell yeah")
+        msg.destroy
+      }.should_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
Given a class with a DateTime range key such as:

``` ruby
class Message
  include Dynamoid::Document
  table name: :messages, key: :message_id
  range :time, :datetime
  field :text
end
```

The AWS SDK will throw an error about DateTime being an unsupported attribute class when delete or destroy is called on the object. This is because the range key field isn't marshalled into it's persisted type (Float).

This pull request fixes the issue by using the dump_field method to convert the range key. Also added a test.

I believe this will also be a problem when updating an object but wasn't able to test properly as updating seems to be broken on master. I think this is down to the method Dynamoid::Adapter.update_item not being present but being called from Dynamoid::Persistence.update.
