### PR TITLE
Default port is 443 not 80 (using ssl)

### DIFF
--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -23,7 +23,7 @@ module Dynamoid
     option :partition_size, :default => 200
     option :endpoint, :default => 'dynamodb.us-east-1.amazonaws.com'
     option :use_ssl, :default => true
-    option :port, :default => '80'
+    option :port, :default => '443'
     option :included_models, :default => []
     option :identity_map, :default => false
 


### PR DESCRIPTION
The configuration has the default port set to '80' but use_ssl = true. This causes an issue with dynamo_db because aws_sdk will honor the port over the use_ssl if the port is set. Also, requests to dynamodb redirect to 443/ssl anyway, so no reason to use 80.
