### PR TITLE
Add support for a boolean type, better error reporting

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -109,6 +109,14 @@ module Dynamoid
           else
             value
           end
+        when :boolean
+          if(value == 't')
+            true
+          elsif(value == 'f')
+            false
+          else
+            raise ArgumentError, "Boolean column neither true nor false"
+          end
         end
       end
 
@@ -225,6 +233,10 @@ module Dynamoid
         value.to_time.to_f
       when :serialized
         options[:serializer] ? options[:serializer].dump(value) : value.to_yaml
+      when :boolean
+        value.to_s[0]
+      else
+        raise ArgumentError, "Unknown type #{options[:type]}"
       end
     end
 

--- a/spec/app/models/address.rb
+++ b/spec/app/models/address.rb
@@ -3,6 +3,7 @@ class Address
   
   field :city
   field :options, :serialized
+  field :deliverable, :boolean
 
   def zip_code=(zip_code)
     self.city = "Chicago"

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -6,7 +6,7 @@ describe "Dynamoid::Document" do
     @address = Address.new
     
     @address.new_record.should be_true
-    @address.attributes.should == {:id=>nil, :created_at=>nil, :updated_at=>nil, :city=>nil, :options=>nil}
+    @address.attributes.should == {:id=>nil, :created_at=>nil, :updated_at=>nil, :city=>nil, :options=>nil, :deliverable => nil}
   end
 
   it 'responds to will_change! methods for all fields' do
@@ -22,7 +22,7 @@ describe "Dynamoid::Document" do
     
     @address.new_record.should be_true
     
-    @address.attributes.should == {:id=>nil, :created_at=>nil, :updated_at=>nil, :city=>"Chicago", :options=>nil}
+    @address.attributes.should == {:id=>nil, :created_at=>nil, :updated_at=>nil, :city=>"Chicago", :options=>nil, :deliverable => nil}
   end
 
   it 'initializes a new document with a virtual attribute' do
@@ -30,7 +30,7 @@ describe "Dynamoid::Document" do
     
     @address.new_record.should be_true
     
-    @address.attributes.should == {:id=>nil, :created_at=>nil, :updated_at=>nil, :city=>"Chicago", :options=>nil}
+    @address.attributes.should == {:id=>nil, :created_at=>nil, :updated_at=>nil, :city=>"Chicago", :options=>nil, :deliverable => nil}
   end
 
   it 'allows interception of write_attribute on load' do

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -36,13 +36,13 @@ describe "Dynamoid::Fields" do
     @address.updated_at.should_not be_nil
     @address.updated_at.class.should == DateTime
   end
-
+  
   context 'with a saved address' do
     before do
-      @address = Address.create
+      @address = Address.create(:deliverable => true)
       @original_id = @address.id
     end
-
+    
     it 'should write an attribute correctly' do
       @address.write_attribute(:city, 'Chicago')
     end
@@ -85,7 +85,7 @@ describe "Dynamoid::Fields" do
     end
 
     it 'returns all attributes' do
-      Address.attributes.should == {:id=>{:type=>:string}, :created_at=>{:type=>:datetime}, :updated_at=>{:type=>:datetime}, :city=>{:type=>:string}, :options=>{:type=>:serialized}}
+      Address.attributes.should == {:id=>{:type=>:string}, :created_at=>{:type=>:datetime}, :updated_at=>{:type=>:datetime}, :city=>{:type=>:string}, :options=>{:type=>:serialized}, :deliverable => {:type => :boolean}}
     end
   end
 


### PR DESCRIPTION
Hello, 

This pull request contains two enhancements: 
- Addition of a boolean column type. It stores the value in Dynamo as either the string 't' or the string 'f' but converts to/from Ruby's constants
- A little nicer error reporting, specifically, it raises ArgumentError when you specify an unsupported column type rather than silently writing nil to the column
