### PR TITLE
Scan Index Forward, update_attributes, Batch Destroy all, and Querying on Partitioned  

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -46,6 +46,63 @@ module Dynamoid #:nodoc:
       def all
         records
       end
+      
+      # Destroys all the records matching the criteria.
+      #
+      def destroy_all
+        ids = []
+        
+        if range?
+          ranges = []
+          Dynamoid::Adapter.query(source.table_name, range_query).collect do |hash| 
+            ids << hash[source.hash_key.to_sym]
+            ranges << hash[source.range_key.to_sym]
+          end
+          
+          Dynamoid::Adapter.delete(source.table_name, ids,{:range_key => ranges})
+        elsif index
+          #TODO: test this throughly and find a way to delete all index table records for one source record
+          if index.range_key?
+            results = Dynamoid::Adapter.query(index.table_name, index_query.merge(consistent_opts))
+          else
+            results = Dynamoid::Adapter.read(index.table_name, index_query[:hash_value], consistent_opts)
+          end
+          
+          results.collect do |hash| 
+            ids << hash[source.hash_key.to_sym]
+            index_ranges << hash[source.range_key.to_sym]
+          end
+        
+          unless ids.nil? || ids.empty?
+            ids = ids.to_a
+  
+            if @start
+              ids = ids.drop_while { |id| id != @start.hash_key }.drop(1)
+              index_ranges = index_ranges.drop_while { |range| range != @start.hash_key }.drop(1) unless index_ranges.nil?
+            end
+  
+            if @limit           
+              ids = ids.take(@limit) 
+              index_ranges = index_ranges.take(@limit)
+            end
+            
+            Dynamoid::Adapter.delete(source.table_name, ids)
+            
+            if index.range_key?
+              Dynamoid::Adapter.delete(index.table_name, ids,{:range_key => index_ranges})
+            else
+              Dynamoid::Adapter.delete(index.table_name, ids)
+            end
+            
+          end
+        else
+          Dynamoid::Adapter.scan(source.table_name, query, scan_opts).collect do |hash| 
+            ids << hash[source.hash_key.to_sym]
+          end
+          
+          Dynamoid::Adapter.delete(source.table_name, ids)
+        end   
+      end
 
       # Returns the first record matching the criteria.
       #
@@ -151,7 +208,7 @@ module Dynamoid #:nodoc:
           raise Dynamoid::Errors::InvalidQuery, 'Consistent read is not supported by SCAN operation'
         end
 
-        Dynamoid::Adapter.scan(source.table_name, query, query_opts).collect {|hash| source.from_database(hash) }
+        Dynamoid::Adapter.scan(source.table_name, query, scan_opts).collect {|hash| source.from_database(hash) }
       end
 
       # Format the provided query so that it can be used to query results from DynamoDB.
@@ -220,7 +277,7 @@ module Dynamoid #:nodoc:
       end
 
       def start_key
-        hash_key_type = @start.class.attributes[@start.class.hash_key][:type] == :string ? 'S' : 'N'
+ 	      hash_key_type = @start.class.attributes[@start.class.hash_key][:type] == :string ? 'S' : 'N'
         key = { :hash_key_element => { hash_key_type => @start.hash_key.to_s } }
         if range_key = @start.class.range_key
           range_key_type = @start.class.attributes[range_key][:type] == :string ? 'S' : 'N'
@@ -234,6 +291,13 @@ module Dynamoid #:nodoc:
         opts[:limit] = @limit if @limit
         opts[:next_token] = start_key if @start
         opts[:scan_index_forward] = @scan_index_forward
+        opts
+      end
+      
+      def scan_opts
+        opts = {}
+        opts[:limit] = @limit if @limit
+        opts[:next_token] = start_key if @start
         opts
       end
     end

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -95,6 +95,8 @@ module Dynamoid #:nodoc:
             end
           end
         end
+        
+        save
       end
     end
 

--- a/spec/dynamoid/adapter/aws_sdk_spec.rb
+++ b/spec/dynamoid/adapter/aws_sdk_spec.rb
@@ -16,11 +16,12 @@ describe Dynamoid::Adapter::AwsSdk do
       end
     end
 
-    context 'with a preexisting table' do
+    context 'with a preexisting table without paritioning' do
       before(:all) do
         Dynamoid::Adapter.create_table('dynamoid_tests_TestTable1', :id) unless Dynamoid::Adapter.list_tables.include?('dynamoid_tests_TestTable1')
         Dynamoid::Adapter.create_table('dynamoid_tests_TestTable2', :id) unless Dynamoid::Adapter.list_tables.include?('dynamoid_tests_TestTable2')
         Dynamoid::Adapter.create_table('dynamoid_tests_TestTable3', :id, :range_key => { :range => :number }) unless Dynamoid::Adapter.list_tables.include?('dynamoid_tests_TestTable3')
+        Dynamoid::Adapter.create_table('dynamoid_tests_TestTable4', :id, :range_key => { :range => :number }) unless Dynamoid::Adapter.list_tables.include?('dynamoid_tests_TestTable4')
       end
 
       # GetItem, PutItem and DeleteItem
@@ -99,6 +100,56 @@ describe Dynamoid::Adapter::AwsSdk do
         results['dynamoid_tests_TestTable3'].should include({:name => 'Josh', :id => '1', :range => 1.0})
         results['dynamoid_tests_TestTable3'].should include({:name => 'Justin', :id => '2', :range => 2.0})
       end
+      
+      # BatchDeleteItem
+      it "performs BatchDeleteItem with singular keys" do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '1', :name => 'Josh'})
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable2', {:id => '1', :name => 'Justin'})
+
+        Dynamoid::Adapter.batch_delete_item('dynamoid_tests_TestTable1' => ['1'], 'dynamoid_tests_TestTable2' => ['1'])
+        
+        results = Dynamoid::Adapter.batch_get_item('dynamoid_tests_TestTable1' => '1', 'dynamoid_tests_TestTable2' => '1')
+        results.size.should == 0
+        
+        results['dynamoid_tests_TestTable1'].should_not include({:name => 'Josh', :id => '1'})
+        results['dynamoid_tests_TestTable2'].should_not include({:name => 'Justin', :id => '1'})
+      end
+
+      it "performs BatchDeleteItem with multiple keys" do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '1', :name => 'Josh'})
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '2', :name => 'Justin'})
+
+        Dynamoid::Adapter.batch_delete_item('dynamoid_tests_TestTable1' => ['1', '2'])
+        
+        results = Dynamoid::Adapter.batch_get_item('dynamoid_tests_TestTable1' => ['1', '2'])
+        results.size.should == 0
+        
+        results['dynamoid_tests_TestTable1'].should_not include({:name => 'Josh', :id => '1'})
+        results['dynamoid_tests_TestTable1'].should_not include({:name => 'Justin', :id => '2'})
+      end
+
+      it 'performs BatchDeleteItem with one ranged key' do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable3', {:id => '1', :name => 'Josh', :range => 1.0})
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable3', {:id => '2', :name => 'Justin', :range => 2.0})
+
+        Dynamoid::Adapter.batch_delete_item('dynamoid_tests_TestTable3' => [['1', 1.0]])
+        results = Dynamoid::Adapter.batch_get_item('dynamoid_tests_TestTable3' => [['1', 1.0]])
+        results.size.should == 0
+
+        results['dynamoid_tests_TestTable3'].should_not include({:name => 'Josh', :id => '1', :range => 1.0})
+      end
+
+      it 'performs BatchDeleteItem with multiple ranged keys' do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable3', {:id => '1', :name => 'Josh', :range => 1.0})
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable3', {:id => '2', :name => 'Justin', :range => 2.0})
+
+        Dynamoid::Adapter.batch_delete_item('dynamoid_tests_TestTable3' => [['1', 1.0],['2', 2.0]])
+        results = Dynamoid::Adapter.batch_get_item('dynamoid_tests_TestTable3' => [['1', 1.0],['2', 2.0]])
+        results.size.should == 0
+         
+        results['dynamoid_tests_TestTable3'].should_not include({:name => 'Josh', :id => '1', :range => 1.0})
+        results['dynamoid_tests_TestTable3'].should_not include({:name => 'Justin', :id => '2', :range => 2.0})
+      end
 
       # ListTables
       it 'performs ListTables' do
@@ -173,6 +224,152 @@ describe Dynamoid::Adapter::AwsSdk do
         Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '2', :name => 'Josh'})
 
         Dynamoid::Adapter.scan('dynamoid_tests_TestTable1', {}).should include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
+      end
+      
+      context 'correct ordering ' do
+        before do
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1', :order => 1, :range => 1.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1', :order => 2, :range => 2.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1', :order => 3, :range => 3.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1', :order => 4, :range => 4.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1', :order => 5, :range => 5.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1', :order => 6, :range => 6.0})
+        end
+
+        it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward true' do
+          query = Dynamoid::Adapter.query('dynamoid_tests_TestTable4', :hash_value => '1', :range_greater_than => 0, :scan_index_forward => true)
+          query[0].should == {:id => '1', :order => 1, :range => BigDecimal.new(1)}
+          query[1].should == {:id => '1', :order => 2, :range => BigDecimal.new(2)}
+          query[2].should == {:id => '1', :order => 3, :range => BigDecimal.new(3)}
+          query[3].should == {:id => '1', :order => 4, :range => BigDecimal.new(4)}
+          query[4].should == {:id => '1', :order => 5, :range => BigDecimal.new(5)}
+          query[5].should == {:id => '1', :order => 6, :range => BigDecimal.new(6)}
+        end
+        
+        it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward false' do
+          query = Dynamoid::Adapter.query('dynamoid_tests_TestTable4', :hash_value => '1', :range_greater_than => 0, :scan_index_forward => false)
+          query[5].should == {:id => '1', :order => 1, :range => BigDecimal.new(1)}
+          query[4].should == {:id => '1', :order => 2, :range => BigDecimal.new(2)}
+          query[3].should == {:id => '1', :order => 3, :range => BigDecimal.new(3)}
+          query[2].should == {:id => '1', :order => 4, :range => BigDecimal.new(4)}
+          query[1].should == {:id => '1', :order => 5, :range => BigDecimal.new(5)}
+          query[0].should == {:id => '1', :order => 6, :range => BigDecimal.new(6)}
+        end
+      end
+    end
+    
+    context 'with a preexisting table with paritioning' do
+      before(:all) do
+        @previous_value = Dynamoid::Config.partitioning
+        Dynamoid::Config.partitioning = true
+        
+        Dynamoid::Adapter.create_table('dynamoid_tests_TestTable1', :id) unless Dynamoid::Adapter.list_tables.include?('dynamoid_tests_TestTable1')
+        Dynamoid::Adapter.create_table('dynamoid_tests_TestTable2', :id) unless Dynamoid::Adapter.list_tables.include?('dynamoid_tests_TestTable2')
+        Dynamoid::Adapter.create_table('dynamoid_tests_TestTable3', :id, :range_key => { :range => :number }) unless Dynamoid::Adapter.list_tables.include?('dynamoid_tests_TestTable3')
+      end
+
+      after(:all) do
+        Dynamoid::Config.partitioning = @previous_value
+      end
+
+      # Query
+      it 'performs query on a table and returns items' do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '1.1', :name => 'Josh'})
+
+        Dynamoid::Adapter.query('dynamoid_tests_TestTable1', :hash_value => '1').first.should == { :id=> '1', :name=>"Josh" }
+      end
+
+      it 'performs query on a table and returns items if there are multiple items' do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '1.1', :name => 'Josh'})
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '2.1', :name => 'Justin'})
+
+        Dynamoid::Adapter.query('dynamoid_tests_TestTable1', :hash_value => '1').first.should == { :id=> '1', :name=>"Josh" }
+      end
+
+      context 'range queries' do
+        before do
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable3', {:id => '1.1', :range => 1.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable3', {:id => '1.1', :range => 3.0})
+        end
+
+        it 'performs query on a table with a range and selects items in a range' do
+          Dynamoid::Adapter.query('dynamoid_tests_TestTable3', :hash_value => '1', :range_value => 0.0..3.0).should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+        end
+
+        it 'performs query on a table with a range and selects items greater than' do
+          Dynamoid::Adapter.query('dynamoid_tests_TestTable3', :hash_value => '1', :range_greater_than => 1.0).should =~ [{:id => '1', :range => BigDecimal.new(3)}]
+        end
+
+        it 'performs query on a table with a range and selects items less than' do
+          Dynamoid::Adapter.query('dynamoid_tests_TestTable3', :hash_value => '1', :range_less_than => 2.0).should =~ [{:id => '1', :range => BigDecimal.new(1)}]
+        end
+
+        it 'performs query on a table with a range and selects items gte' do
+          Dynamoid::Adapter.query('dynamoid_tests_TestTable3', :hash_value => '1', :range_gte => 1.0).should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+        end
+
+        it 'performs query on a table with a range and selects items lte' do
+          Dynamoid::Adapter.query('dynamoid_tests_TestTable3', :hash_value => '1', :range_lte => 3.0).should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+        end
+      end
+
+      # Scan
+      it 'performs scan on a table and returns items' do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '1.1', :name => 'Josh'})
+
+        Dynamoid::Adapter.scan('dynamoid_tests_TestTable1', :name => 'Josh').should == [{ :id=> '1', :name=>"Josh" }]
+      end
+
+      it 'performs scan on a table and returns items if there are multiple items but only one match' do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '1.1', :name => 'Josh'})
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '2.1', :name => 'Justin'})
+
+        Dynamoid::Adapter.scan('dynamoid_tests_TestTable1', :name => 'Josh').should == [{ :id=> '1', :name=>"Josh" }]
+      end
+
+      it 'performs scan on a table and returns multiple items if there are multiple matches' do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '1.1', :name => 'Josh'})
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '2.1', :name => 'Josh'})
+
+        Dynamoid::Adapter.scan('dynamoid_tests_TestTable1', :name => 'Josh').should include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
+      end
+
+      it 'performs scan on a table and returns all items if no criteria are specified' do
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '1.1', :name => 'Josh'})
+        Dynamoid::Adapter.put_item('dynamoid_tests_TestTable1', {:id => '2.1', :name => 'Josh'})
+
+        Dynamoid::Adapter.scan('dynamoid_tests_TestTable1', {}).should include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
+      end
+      
+      context 'correct ordering ' do
+        before do
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1.1', :range => 1.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1.2', :range => 2.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1.3', :range => 3.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1.4', :range => 4.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1.5', :range => 5.0})
+          Dynamoid::Adapter.put_item('dynamoid_tests_TestTable4', {:id => '1.6', :range => 6.0})
+        end
+
+        it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward true' do
+          query = Dynamoid::Adapter.query('dynamoid_tests_TestTable4', :hash_value => '1', :range_greater_than => 0, :scan_index_forward => true)
+          query[0].should == {:id => '1', :range => BigDecimal.new(1)}
+          query[1].should == {:id => '1', :range => BigDecimal.new(2)}
+          query[2].should == {:id => '1', :range => BigDecimal.new(3)}
+          query[3].should == {:id => '1', :range => BigDecimal.new(4)}
+          query[4].should == {:id => '1', :range => BigDecimal.new(5)}
+          query[5].should == {:id => '1', :range => BigDecimal.new(6)}
+        end
+        
+        it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward false' do
+          query = Dynamoid::Adapter.query('dynamoid_tests_TestTable4', :hash_value => '1', :range_greater_than => 0, :scan_index_forward => false)
+          query[5].should == {:id => '1', :range => BigDecimal.new(1)}
+          query[4].should == {:id => '1', :range => BigDecimal.new(2)}
+          query[3].should == {:id => '1', :range => BigDecimal.new(3)}
+          query[2].should == {:id => '1', :range => BigDecimal.new(4)}
+          query[1].should == {:id => '1', :range => BigDecimal.new(5)}
+          query[0].should == {:id => '1', :range => BigDecimal.new(6)}
+        end
       end
     end
 

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -136,5 +136,28 @@ describe "Dynamoid::Associations::Chain" do
       @chain.send(:records_with_range).should == [@tweet3]
     end
   end
+  
+  context 'destroy alls' do
+    before do
+      @tweet1 = Tweet.create(:tweet_id => "x", :group => "one")
+      @tweet2 = Tweet.create(:tweet_id => "x", :group => "two")
+      @tweet3 = Tweet.create(:tweet_id => "xx", :group => "two")
+      @chain = Dynamoid::Criteria::Chain.new(Tweet)
+    end
+    
+    it 'destroys tweet with a range simple range query' do
+      @chain.query = { :tweet_id => "x" }
+      @chain.all.size.should == 2
+      @chain.destroy_all
+      @chain.consistent.all.size.should == 0
+    end
 
+    it 'deletes one specific tweet with range' do
+      @chain = Dynamoid::Criteria::Chain.new(Tweet)
+      @chain.query = { :tweet_id => "xx", :group => "two" }
+      @chain.all.size.should == 1
+      @chain.destroy_all
+      @chain.consistent.all.size.should == 0
+    end
+  end
 end


### PR DESCRIPTION
Fixed issue with sendings a :scan_index_forward to a SCAN request.

Ran tests and found failed test with update_attributes as the test requires a save to be called after new attributes are loaded.

Tests are running 100%.

Added the ability to query with partitioning on. Also added destroy_all to chain.

Indexed query destroy_all not tested. Only on single table QUERY/SCANs.

Not sure of the efficiency of any of this but it works.

Tests cases added as well.

Found bug with the ordering of items after a partitioned query, made test case that validates this bug, so currently one test is broken.
