### PR TITLE
Check for existence on creation rather than silently clobber

### DIFF
--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -45,16 +45,17 @@ module Dynamoid
     #
     # @param [String] table the name of the table to write the object to
     # @param [Object] object the object itself
+    # @param [Hash] options Options that are passed to the put_item call
     #
     # @return [Object] the persisted object
     #
     # @since 0.2.0
-    def write(table, object)
+    def write(table, object, options = nil)
       if Dynamoid::Config.partitioning? && object[:id]
         object[:id] = "#{object[:id]}.#{Random.rand(Dynamoid::Config.partition_size)}"
         object[:updated_at] = Time.now.to_f
       end
-      put_item(table, object)
+      put_item(table, object, options)
     end
 
     # Read one or many keys from the selected table. This method intelligently calls batch_get or get on the underlying adapter depending on

--- a/lib/dynamoid/adapter/aws_sdk.rb
+++ b/lib/dynamoid/adapter/aws_sdk.rb
@@ -150,9 +150,12 @@ module Dynamoid
       # @param [Object] object a hash or Dynamoid object to persist
       #
       # @since 0.2.0
-      def put_item(table_name, object)
+      def put_item(table_name, object, options = nil)
         table = get_table(table_name)
-        table.items.create(object.delete_if{|k, v| v.nil? || (v.respond_to?(:empty?) && v.empty?)})
+        table.items.create(
+          object.delete_if{|k, v| v.nil? || (v.respond_to?(:empty?) && v.empty?)},
+          options || {}
+        )
       end
 
       # Query the DynamoDB table. This employs DynamoDB's indexes so is generally faster than scanning, but is

--- a/spec/dynamoid/adapter_spec.rb
+++ b/spec/dynamoid/adapter_spec.rb
@@ -25,7 +25,7 @@ describe "Dynamoid::Adapter" do
     end
     
     it 'writes through the adapter' do
-      Dynamoid::Adapter.expects(:put_item).with('dynamoid_tests_TestTable', {:id => '123'}).returns(true)
+      Dynamoid::Adapter.expects(:put_item).with('dynamoid_tests_TestTable', {:id => '123'}, nil).returns(true)
 
       Dynamoid::Adapter.write('dynamoid_tests_TestTable', {:id => '123'})
     end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -126,6 +126,23 @@ describe "Dynamoid::Persistence" do
 
     lambda {Address.create(hash)}.should_not raise_error
   end
+  
+  context 'create' do
+    {
+      Tweet   => ['with range',    { :tweet_id => 1, :group => 'abc' }],
+      Message => ['without range', { :message_id => 1, :text => 'foo', :time => DateTime.now }]
+    }.each_pair do |clazz, fields|
+      it "checks for existence of an existing object #{fields[0]}" do
+        t1 = clazz.new(fields[1])
+        t2 = clazz.new(fields[1])
+      
+        t1.save
+        expect do
+          t2.save!
+        end.to raise_exception AWS::DynamoDB::Errors::ConditionalCheckFailedException
+      end
+    end
+  end
 
   context 'update' do
 


### PR DESCRIPTION
Hello, 

I noticed that if two competing threads attempt to create objects concurrently with the same key, one will silently clobber the other since Dynamoid does an unconditional put on new records. This patch adds an unless_exists clause to the put_item request so that one will fail. This is more consistent with the behavior of ActiveRecord and avoids silent data corruption. 
