### PR TITLE
During automatic table generation options

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -156,7 +156,7 @@ module Dynamoid
     #
     # @since 0.2.0
     def save(options = {})
-      self.class.create_table
+      self.class.create_table(options)
       
       if new_record?
         conditions = { :unless_exists => [self.class.hash_key]}


### PR DESCRIPTION
When a table is automatically generated, I have modified to be able to specify the options.
If the table does not exist, automatically generates a table before saving the record.
However, type of id always becomes "string".
