### PR TITLE
Add TravisCI to the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+ruby:
+  - 1.9.3
+script: bundle exec rake unattended_spec

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,6 @@ group :development do
   gem "redcarpet", '1.17.2'
   gem 'github-markup'
   gem 'pry'
-  gem 'fake_dynamo'
+  gem 'fake_dynamo', '>=0.1.3'
   gem "mocha", '0.10.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     builder (3.0.0)
     coderay (1.0.7)
     diff-lcs (1.1.3)
-    fake_dynamo (0.0.9)
+    fake_dynamo (0.1.3)
       activesupport
       json
       sinatra
@@ -42,8 +42,8 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.3.1)
-    rack (1.4.1)
-    rack-protection (1.2.0)
+    rack (1.5.2)
+    rack-protection (1.5.0)
       rack
     rake (0.9.2.2)
     rdoc (3.12)
@@ -62,7 +62,7 @@ GEM
       rack-protection (~> 1.2)
       tilt (~> 1.3, >= 1.3.3)
     slop (3.3.2)
-    tilt (1.3.3)
+    tilt (1.3.7)
     tzinfo (0.3.33)
     uuidtools (2.1.3)
     yard (0.8.2.1)
@@ -74,7 +74,7 @@ DEPENDENCIES
   activemodel
   aws-sdk
   bundler
-  fake_dynamo
+  fake_dynamo (>= 0.1.3)
   github-markup
   jeweler
   mocha (= 0.10.0)


### PR DESCRIPTION
Hello, 

I added support for TravisCI. If you merge this pull request (and turn on TravisCI for your account), all future pull requests will have the tests automatically run against them and the results will be listed in the comments. Notably, this includes a single rake task that will start fake_dynamo, run the tests, terminate fake_dynamo, and then clean up the fdb file. 

Josh, to activate Travis, go to https://travis-ci.org, log in using your GitHub account, and then enable Travis for your Dynamoid repository. 
