### PR TITLE
Adding count to document using describe_table

### DIFF
--- a/lib/dynamoid/adapter/aws_sdk.rb
+++ b/lib/dynamoid/adapter/aws_sdk.rb
@@ -262,10 +262,6 @@ module Dynamoid
       def table_cache
         @table_cache ||= {}
       end
-
-      def describe_table(table_name)
-        @@connection.describe_table(table_name)
-      end
     end
   end
 end

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -56,7 +56,7 @@ module Dynamoid #:nodoc:
       end
 
       def count
-        1234
+        Dynamoid::Adapter.connection.client.describe_table(table_name: table_name)["Table"]["ItemCount"]
       end
 
       # Initialize a new object and immediately save it to the database.


### PR DESCRIPTION
Maybe we can refactor in adding describe_table in aws_sdk ?

This is working but if the table doesn't exist, it returns error :
AWS::DynamoDB::Errors::ResourceNotFoundException: Requested resource not found: Table: copyrightly_development_videos not found

Thanks
