### PR TITLE
Switch Dynamoid to use Enumerator instead of Arrays

### DIFF
--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -188,7 +188,7 @@ module Dynamoid
         range_key_name = table.range_key.name.to_sym
         
         final_hash = {}
-        
+
         results.each do |record|
           test_record = final_hash[record[range_key_name]]
           
@@ -257,11 +257,9 @@ module Dynamoid
           modified_options[:hash_value] = id
 
           query_result = Dynamoid::Adapter::AwsSdk.query(table_name, modified_options)
-          query_result = [query_result] if !query_result.is_a?(Array)
-
-          results = results + query_result unless query_result.nil? 
+          results += query_result.inject([]){|array, result| array += [result]} if query_result.any?
         end 
-        
+
         result_for_partition results, table_name
       end
     end

--- a/spec/dynamoid/adapter/aws_sdk_spec.rb
+++ b/spec/dynamoid/adapter/aws_sdk_spec.rb
@@ -50,23 +50,27 @@ describe Dynamoid::Adapter::AwsSdk do
     end
 
     it 'performs query on a table with a range and selects items in a range' do
-      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_value => 0.0..3.0).should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_value => 0.0..3.0).to_a.should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+    end
+
+    it 'performs query on a table with a range and selects items in a range with :select option' do
+      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_value => 0.0..3.0, :select => :all).to_a.should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
     end
 
     it 'performs query on a table with a range and selects items greater than' do
-      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_greater_than => 1.0).should =~ [{:id => '1', :range => BigDecimal.new(3)}]
+      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_greater_than => 1.0).to_a.should =~ [{:id => '1', :range => BigDecimal.new(3)}]
     end
 
     it 'performs query on a table with a range and selects items less than' do
-      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_less_than => 2.0).should =~ [{:id => '1', :range => BigDecimal.new(1)}]
+      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_less_than => 2.0).to_a.should =~ [{:id => '1', :range => BigDecimal.new(1)}]
     end
 
     it 'performs query on a table with a range and selects items gte' do
-      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_gte => 1.0).should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_gte => 1.0).to_a.should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
     end
 
     it 'performs query on a table with a range and selects items lte' do
-      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_lte => 3.0).should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+      Dynamoid::Adapter.query(test_table3, :hash_value => '1', :range_lte => 3.0).to_a.should =~ [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
     end
   end
   
@@ -85,7 +89,7 @@ describe Dynamoid::Adapter::AwsSdk do
     end
 
     it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward true' do
-      query = Dynamoid::Adapter.query(test_table4, :hash_value => '1', :range_greater_than => 0, :scan_index_forward => true)
+      query = Dynamoid::Adapter.query(test_table4, :hash_value => '1', :range_greater_than => 0, :scan_index_forward => true).to_a
       query[0].should == {:id => '1', :order => 1, :range => BigDecimal.new(1)}
       query[1].should == {:id => '1', :order => 2, :range => BigDecimal.new(2)}
       query[2].should == {:id => '1', :order => 3, :range => BigDecimal.new(3)}
@@ -95,7 +99,7 @@ describe Dynamoid::Adapter::AwsSdk do
     end
     
     it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward false' do
-      query = Dynamoid::Adapter.query(test_table4, :hash_value => '1', :range_greater_than => 0, :scan_index_forward => false)
+      query = Dynamoid::Adapter.query(test_table4, :hash_value => '1', :range_greater_than => 0, :scan_index_forward => false).to_a
       query[5].should == {:id => '1', :order => 1, :range => BigDecimal.new(1)}
       query[4].should == {:id => '1', :order => 2, :range => BigDecimal.new(2)}
       query[3].should == {:id => '1', :order => 3, :range => BigDecimal.new(3)}
@@ -264,14 +268,14 @@ describe Dynamoid::Adapter::AwsSdk do
     it 'performs query on a table and returns items' do
       Dynamoid::Adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
 
-      Dynamoid::Adapter.query(test_table1, :hash_value => '1').should == { :id=> '1', :name=>"Josh" }
+      Dynamoid::Adapter.query(test_table1, :hash_value => '1').first.should == { :id=> '1', :name=>"Josh" }
     end
 
     it 'performs query on a table and returns items if there are multiple items' do
       Dynamoid::Adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid::Adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
 
-      Dynamoid::Adapter.query(test_table1, :hash_value => '1').should == { :id=> '1', :name=>"Josh" }
+      Dynamoid::Adapter.query(test_table1, :hash_value => '1').first.should == { :id=> '1', :name=>"Josh" }
     end
     
     it_behaves_like 'range queries'
@@ -280,14 +284,14 @@ describe Dynamoid::Adapter::AwsSdk do
     it 'performs scan on a table and returns items' do
       Dynamoid::Adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
 
-      Dynamoid::Adapter.scan(test_table1, :name => 'Josh').should == [{ :id=> '1', :name=>"Josh" }]
+      Dynamoid::Adapter.scan(test_table1, :name => 'Josh').to_a.should == [{ :id=> '1', :name=>"Josh" }]
     end
 
     it 'performs scan on a table and returns items if there are multiple items but only one match' do
       Dynamoid::Adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid::Adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
 
-      Dynamoid::Adapter.scan(test_table1, :name => 'Josh').should == [{ :id=> '1', :name=>"Josh" }]
+      Dynamoid::Adapter.scan(test_table1, :name => 'Josh').to_a.should == [{ :id=> '1', :name=>"Josh" }]
     end
 
     it 'performs scan on a table and returns multiple items if there are multiple matches' do


### PR DESCRIPTION
This is the first commit where I convert Dynamoid to use Enumerators. The reason for this commit is dynamodb sdk has a batch_size property which allows you to essentially iterate over a large list but retrieve the items in batches and only they are needed.

Since dynamoid itself has always retrieved all the items prior to doing any work this meant that certain operations, like .all, would fail as the total rows in a table got bigger.

I've also added a small fix to query to allow the :select option which allows the query to return all the results in the response to the query if people want to use that.

I need to add a few more tests to be confident in the changes and some more documentation to explain the benefits but I wanted to open the pull request now to get the discussion going on how this is being done.
