### PR TITLE
Fix some broken tests

### DIFF
--- a/spec/dynamoid/adapter_spec.rb
+++ b/spec/dynamoid/adapter_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Dynamoid::Adapter do
   
-  let(:test_table){'dynamoid_tests_TestTable'}
+  def test_table; 'dynamoid_tests_TestTable'; end
   let(:single_id){'123'}
   let(:many_ids){%w(1 2)}
 

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -172,9 +172,10 @@ describe "Dynamoid::Associations::Chain" do
     end
 
     it 'throws exception if partitioning is used with batching' do
+      previous_value = Dynamoid::Config.partitioning
       Dynamoid::Config.partitioning = true
-
       expect { @chain.batch(2) }.to raise_error
+      Dynamoid::Config.partitioning = previous_value
     end
   end
 end

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "Dynamoid::Criteria" do
+  before(:all) do
+    Magazine.create_table
+  end
   
   before do
     @user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')


### PR DESCRIPTION
Some test-breaking code snuck its way in. Specifically, one new test was turning on partitioning but not reseting it to its previous state, breaking downstream tests. 

Also, a newer version of rspec was warning about deprecated behaviors in the tests, so I fixed that as well. 
