### PR TITLE
Single table inheritance

### DIFF
--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -14,7 +14,7 @@ module Dynamoid
 
       before_create :set_created_at
       before_save :set_updated_at
-      before_save :set_type
+      after_initialize :set_type
     end
 
     include ActiveModel::AttributeMethods

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -8,9 +8,10 @@ module Dynamoid #:nodoc:
     include Dynamoid::Components
 
     included do
-      class_attribute :options, :read_only_attributes
+      class_attribute :options, :read_only_attributes, :base_class
       self.options = {}
       self.read_only_attributes = []
+      self.base_class = self
 
       Dynamoid::Config.included_models << self
     end
@@ -110,8 +111,6 @@ module Dynamoid #:nodoc:
     # @since 0.2.0
     def initialize(attrs = {})
       run_callbacks :initialize do
-        self.class.send(:field, self.class.hash_key) unless self.respond_to?(self.class.hash_key)
-
         @new_record = true
         @attributes ||= {}
         @associations ||= {}

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -14,6 +14,8 @@ module Dynamoid #:nodoc:
       self.attributes = {}
       field :created_at, :datetime
       field :updated_at, :datetime
+
+      field :id #Default primary key
     end
 
     module ClassMethods
@@ -28,7 +30,7 @@ module Dynamoid #:nodoc:
       # @since 0.2.0
       def field(name, type = :string, options = {})
         named = name.to_s
-        self.attributes[name] = {:type => type}.merge(options)
+        self.attributes = attributes.merge(name => {:type => type}.merge(options))
 
         define_method(named) { read_attribute(named) }
         define_method("#{named}?") { !read_attribute(named).nil? }
@@ -38,6 +40,14 @@ module Dynamoid #:nodoc:
       def range(name, type = :string)
         field(name, type)
         self.range_key = name
+      end
+
+      def table(options)
+        #a default 'id' column is created when Dynamoid::Document is included
+        unless(attributes.has_key? hash_key)
+          remove_field :id
+          field(hash_key)
+        end
       end
 
       def remove_field(field)

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -13,11 +13,8 @@ module Dynamoid
 
     module ClassMethods
 
-      # Returns the name of the table the class is for.
-      #
-      # @since 0.2.0
       def table_name
-        "#{Dynamoid::Config.namespace}_#{options[:name] ? options[:name] : self.name.split('::').last.downcase.pluralize}"
+        @table_name ||= "#{Dynamoid::Config.namespace}_#{options[:name] || base_class.name.split('::').last.downcase.pluralize}"
       end
 
       # Creates a table.

--- a/spec/app/models/car.rb
+++ b/spec/app/models/car.rb
@@ -1,0 +1,6 @@
+require_relative 'vehicle'
+
+class Car < Vehicle
+  
+  field :power_locks, :boolean
+end

--- a/spec/app/models/nuclear_submarine.rb
+++ b/spec/app/models/nuclear_submarine.rb
@@ -1,0 +1,5 @@
+require_relative 'vehicle'
+class NuclearSubmarine < Vehicle
+  
+  field :torpedoes, :integer
+end

--- a/spec/app/models/vehicle.rb
+++ b/spec/app/models/vehicle.rb
@@ -1,0 +1,7 @@
+class Vehicle
+  include Dynamoid::Document
+  
+  field :type
+  
+  field :description
+end

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -161,4 +161,15 @@ describe "Dynamoid::Document" do
       document.should_not == different
     end
   end
+
+  context 'single table inheritance' do
+    it "should have a type" do
+      Vehicle.new.type.should == "Vehicle"
+    end
+
+    it "reports the same table name for both base and derived classes" do
+      Vehicle.table_name.should == Car.table_name
+      Vehicle.table_name.should == NuclearSubmarine.table_name
+    end
+  end
 end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -36,13 +36,13 @@ describe "Dynamoid::Fields" do
     @address.updated_at.should_not be_nil
     @address.updated_at.class.should == DateTime
   end
-  
+
   context 'with a saved address' do
     before do
       @address = Address.create(:deliverable => true)
       @original_id = @address.id
     end
-    
+
     it 'should write an attribute correctly' do
       @address.write_attribute(:city, 'Chicago')
     end
@@ -139,6 +139,17 @@ describe "Dynamoid::Fields" do
       @doc.save!
       @doc.reload.name.should eq('x')
       @doc.uid.should eq(42)
+    end
+  end
+
+  context 'single table inheritance' do
+    it "has only base class fields on the base class" do
+      Vehicle.attributes.keys.to_set.should == Set.new([:type, :description, :created_at, :updated_at, :id])
+    end
+
+    it "has only the base and derived fields on a sub-class" do
+      #Only NuclearSubmarines have torpedoes
+      Car.attributes.should_not have_key(:torpedoes)
     end
   end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -278,4 +278,24 @@ describe "Dynamoid::Persistence" do
       }.should_not raise_error
     end
   end
+
+  context 'single table inheritance' do
+    let(:car) { Car.create(power_locks: false) }
+    let(:sub) { NuclearSubmarine.create(torpedoes: 5) }
+
+    it 'saves subclass objects in the parent table' do
+      c = car
+      Vehicle.find(c.id).should == c
+    end
+
+    it 'loads subclass item when querying the parent table' do
+      c = car
+      s = sub
+
+      Vehicle.all.to_a.tap { |v|
+        v.should include(c)
+        v.should include(s)
+      }
+    end
+  end
 end


### PR DESCRIPTION
I've fixed up the single table inheritance support to include tests. 

In the process, I found that the definition of fields didn't work properly, especially the lazy definition of a primary key. A primary key is now immediately defined when Dynamoid::Document is included, and then removed by the table() declaration if a different key is specified. Otherwise, a derived class won't have an id column unless the parent class has been instantiated at least once. 
