### PR TITLE
use consistent_read for .reload

### DIFF
--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -147,14 +147,14 @@ module Dynamoid #:nodoc:
     end
 
     # Reload an object from the database -- if you suspect the object has changed in the datastore and you need those
-    # changes to be reflected immediately, you would call this method.
+    # changes to be reflected immediately, you would call this method. This is a consistent read.
     #
     # @return [Dynamoid::Document] the document this method was called on
     #
     # @since 0.2.0
     def reload
       range_key_value = range_value ? dumped_range_value : nil
-      self.attributes = self.class.find(hash_key, :range_key => range_key_value).attributes
+      self.attributes = self.class.find(hash_key, :range_key => range_key_value, :consistent_read => true).attributes
       @associations.values.each(&:reset)
       self
     end


### PR DESCRIPTION
This changes document.reload to use a `:consistent_read => true` by default. I cleaned up the tests a little too.

The document `.reload` method is used when you have a record and want to load it again, typically to refresh the attributes. Without this patch, the problem is that `.reload` could be inconsistent, and actually not pick up recent changes. I could not think of any use case where you want to reload in in an inconsistent manner. Records can still be found with a `:consistent_read => false` using the `.find` method, however that is not intuitively what `.reload` should be doing and that is why I did not make it an option.
