### PR TITLE
Invoke srand before using Random.rand

### DIFF
--- a/lib/dynamoid.rb
+++ b/lib/dynamoid.rb
@@ -31,6 +31,7 @@ module Dynamoid
   MAX_ITEM_SIZE = 65_536
   
   def configure
+    srand
     block_given? ? yield(Dynamoid::Config) : Dynamoid::Config
     Dynamoid::Adapter.reconnect!
   end


### PR DESCRIPTION
`Random.rand` segfaults on some rubies if it hasn't been initialized by a call to `srand` - this happened to me today:

``` shell
$ rails console
irb(main):001:0> Random.rand
(irb):1: [BUG] Segmentation fault
ruby 1.9.3p194 (2012-04-20 revision 35410) [i686-linux]
```

Also see this bug report: https://rubyforge.org/tracker/index.php?func=detail&aid=29627&group_id=524&atid=2086

So let's call `srand` before invoking `Random.rand` to avoid this.
