### PR TITLE
ActiveModel 4 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+gemfile:
+  - Gemfile
+  - Gemfile_activemodel4
 ruby:
   - 1.9.3
 script: bundle exec rake unattended_spec

--- a/Gemfile_activemodel4
+++ b/Gemfile_activemodel4
@@ -1,0 +1,24 @@
+source "https://rubygems.org"
+
+gem 'activemodel', '~>4.0.0'
+gem 'tzinfo'
+gem 'aws-sdk'
+
+# Add dependencies required to use your gem here.
+# Example:
+#   gem "activesupport", ">= 2.3.5"
+
+# Add dependencies to develop your gem here.
+# Include everything needed to run rake, tests, features, etc.
+group :development do
+  gem "rake"
+  gem "rspec"
+  gem "bundler"
+  gem "jeweler"
+  gem "yard"
+  gem "redcarpet", '1.17.2'
+  gem 'github-markup'
+  gem 'pry'
+  gem 'fake_dynamo', '~>0.1.3'
+  gem "mocha", '0.10.0'
+end

--- a/Gemfile_activemodel4.lock
+++ b/Gemfile_activemodel4.lock
@@ -1,0 +1,88 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.0.0)
+      activesupport (= 4.0.0)
+      builder (~> 3.1.0)
+    activesupport (4.0.0)
+      i18n (~> 0.6, >= 0.6.4)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
+    atomic (1.1.10)
+    aws-sdk (1.10.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+      uuidtools (~> 2.1)
+    builder (3.1.4)
+    coderay (1.0.9)
+    diff-lcs (1.2.4)
+    fake_dynamo (0.1.3)
+      activesupport
+      json
+      sinatra
+    git (1.2.5)
+    github-markup (0.7.5)
+    i18n (0.6.4)
+    jeweler (1.8.4)
+      bundler (~> 1.0)
+      git (>= 1.2.5)
+      rake
+      rdoc
+    json (1.8.0)
+    metaclass (0.0.1)
+    method_source (0.8.1)
+    minitest (4.7.5)
+    mocha (0.10.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.7.7)
+    nokogiri (1.5.9)
+    pry (0.9.12.2)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    rack (1.5.2)
+    rack-protection (1.5.0)
+      rack
+    rake (10.0.4)
+    rdoc (4.0.1)
+      json (~> 1.4)
+    redcarpet (1.17.2)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
+    sinatra (1.4.2)
+      rack (~> 1.5, >= 1.5.2)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    slop (3.4.5)
+    thread_safe (0.1.0)
+      atomic
+    tilt (1.4.1)
+    tzinfo (0.3.37)
+    uuidtools (2.1.4)
+    yard (0.8.6.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activemodel (~> 4.0.0)
+  aws-sdk
+  bundler
+  fake_dynamo (~> 0.1.3)
+  github-markup
+  jeweler
+  mocha (= 0.10.0)
+  pry
+  rake
+  redcarpet (= 1.17.2)
+  rspec
+  tzinfo
+  yard

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -19,9 +19,9 @@ module Dynamoid
 
     include ActiveModel::AttributeMethods
     include ActiveModel::Conversion
-    include ActiveModel::MassAssignmentSecurity
+    include ActiveModel::MassAssignmentSecurity if defined?(ActiveModel::MassAssignmentSecurity)
     include ActiveModel::Naming
-    include ActiveModel::Observing
+    include ActiveModel::Observing if defined?(ActiveModel::Observing)
     include ActiveModel::Serializers::JSON
     include ActiveModel::Serializers::Xml
     include Dynamoid::Fields

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -8,7 +8,7 @@ module Dynamoid
   module Config
     extend self
     extend Options
-    include ActiveModel::Observing
+    include ActiveModel::Observing if defined?(ActiveModel::Observing)
 
     # All the default options.
     option :adapter, :default => 'aws-sdk'


### PR DESCRIPTION
With this patch all tests pass using ActiveModel 4. It does that by not loading modules that have been removed, namely `ActiveModel::MassAssignmentSecurity` and `ActiveModel::Observing`.
