### PR TITLE
Fix range queries - cast symbol to string before splitting

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -252,7 +252,7 @@ module Dynamoid #:nodoc:
 
         return { :range_value => query[key] } if query[key].is_a?(Range)
 
-        case key.split('.').last
+        case key.to_s.split('.').last
         when 'gt'
           { :range_greater_than => val.to_f }
         when 'lt'


### PR DESCRIPTION
Don't crap out when doing something like
Object.where(hash_key => "value" , "range_key.begins_with" => "prefix").all
