### PR TITLE
Cast the range key to string before checking for range queries; add support for eq in range queries

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -252,7 +252,7 @@ module Dynamoid #:nodoc:
 
         return { :range_value => query[key] } if query[key].is_a?(Range)
 
-        case key.split('.').last
+        case key.to_s.split('.').last
         when 'gt'
           { :range_greater_than => val.to_f }
         when 'lt'

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -253,6 +253,8 @@ module Dynamoid #:nodoc:
         return { :range_value => query[key] } if query[key].is_a?(Range)
 
         case key.to_s.split('.').last
+        when 'eq'
+          { :range_value => val }
         when 'gt'
           { :range_greater_than => val.to_f }
         when 'lt'


### PR DESCRIPTION
As the title says:

- convert the key for range queries to string before splitting
- Add support for the EQ range query