### PR TITLE
Add select "all" in absence of any interface to set 'select option on DynamoDB query

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -305,6 +305,7 @@ module Dynamoid #:nodoc:
 
       def query_opts
         opts = {}
+        opts[:select] = :all
         opts[:limit] = @limit if @limit
         opts[:next_token] = start_key if @start
         opts[:scan_index_forward] = @scan_index_forward


### PR DESCRIPTION
Since the select option is never passed through from the ActiveRecord layer, it's never used.  While it might be nice to support that, at present it's helpful to set select to 'all'.  This improves performance in many cases, avoiding another network hit to do 'get_item' for each result in a query.
