### PR TITLE
Fixed typo in README.markdown in Associations example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -187,7 +187,7 @@ class Address
 
   ...
 
-  belongs_to :address # Automatically links up with the user model
+  belongs_to :user # Automatically links up with the user model
 
 end
 ```


### PR DESCRIPTION
Existing README.markdown has an error in the Associations section.  The Address model has association

``` ruby
belongs_to :address
```

where the correct association _should_ link the Address model to the User model.

``` ruby
belongs_to :user
```

This pull request fixes this typo.
