### PR TITLE
Add an option for ignoring undefined field

### DIFF
--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -26,6 +26,7 @@ module Dynamoid
     option :port, :default => '443'
     option :included_models, :default => []
     option :identity_map, :default => false
+    option :ignore_undefined_fileds, :default => false
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -130,7 +130,13 @@ module Dynamoid #:nodoc:
     end
 
     def load(attrs)
-      self.class.undump(attrs).each {|key, value| send "#{key}=", value }
+      self.class.undump(attrs).each do |key, value|
+        if Dynamoid::Config.ignore_undefined_fileds
+          send "#{key}=", value if respond_to? "#{key}="
+        else
+          send "#{key}=", value
+        end
+      end
     end
 
     # An object is equal to another object if their ids are equal.

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -177,4 +177,20 @@ describe "Dynamoid::Document" do
       Tweet.count.should == 2
     end
   end
+
+  context 'load with undefined field attributes' do
+    before do
+      Dynamoid.configure{ |config| config.ignore_undefined_fileds = true }
+    end
+    it 'ignores undefined fields' do
+      Address.field :foo
+      address = Address.create(:foo => "bar")
+      Address.remove_field :foo
+      expect{ Address.find(address.id) }.not_to raise_exception(NoMethodError)
+      address.destroy
+    end
+    after do
+      Dynamoid.configure{ |config| config.ignore_undefined_fileds = false }
+    end
+  end
 end


### PR DESCRIPTION
When I remove a field from a model, I have to remove the corresponding attribute  from all saved items in DynamoDB. That is for avoiding `NoMethodError` on loading an item from DB. That may require to stop the web service during running a script of deleting that attributes. This commit is a proposal of adding an option to ignore undefined (but attributes are exist in saved items) fields on loading an item.

What do you think about this new option?
