### PR TITLE
Fix README aws.yml alias

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,7 +39,7 @@ Fill in your AWS Access Key ID and Secret Access Key
 ```ruby
 
 
-  development:
+  development: &development
     access_key_id: REPLACE_WITH_ACCESS_KEY_ID
     secret_access_key: REPLACE_WITH_SECRET_ACCESS_KEY
     dynamo_db_endpoint:  dynamodb.ap-southeast-1.amazonaws.com


### PR DESCRIPTION
Fixes the aws.yml in the readme to have the appropriate alias. Fixing the error:
```
'block in visit_Psych_Nodes_Alias': 
Unknown alias: development (Psych::BadAlias) 
```