### PR TITLE
Remove to_f in criteria chain

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -254,13 +254,13 @@ module Dynamoid #:nodoc:
 
         case key.to_s.split('.').last
         when 'gt'
-          { :range_greater_than => val.to_f }
+          { :range_greater_than => val }
         when 'lt'
-          { :range_less_than  => val.to_f }
+          { :range_less_than  => val }
         when 'gte'
-          { :range_gte  => val.to_f }
+          { :range_gte  => val }
         when 'lte'
-          { :range_lte => val.to_f }
+          { :range_lte => val }
         when 'begins_with'
           { :range_begins_with => val }
         end


### PR DESCRIPTION
According to the document, in api version 2012-08-10, range key can be either String, Integer or Binary when it comes with comparison conditions. (e.g. gt, lt, gte, ...)
I guess it's user's responsibility to make range keys match with schema definition and should omit this conversion so that we can make use of comparison conditions not only with Integer but also String and/or other data types.

Please review it. :bow: